### PR TITLE
Do not need jQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ A Cytoscape.js extension to provide copy-paste utilities, distributed under [The
 ```javascript
     var cy = cytoscape({...});
 
-    var cb = cy.clipboard(options);
+    var cb = cy.clipboard();
 
 ```
 
 
-`cy.clipboard(options)`
-Initializes extension & sets options.
+`cy.clipboard()`
 
 `cb.copy(eles [, id])`
 Copies eles and returns id of operation. If `id` is not specified, it will be assigned automatically.
@@ -25,17 +24,8 @@ Copies eles and returns id of operation. If `id` is not specified, it will be as
 `cb.paste([id])`
 Pastes the copied elements which has `id`. If `id` is not specified, it will have the last operation's id.
 
-
-## Default Options
-```javascript
-            var options = {
-                clipboardSize: 0
-            };
-```
-
-
 ## Default Undo Redo Actions
-`ur.do("paste"[, { id: idOfOperation }])` 
+`ur.do("paste"[, { id: idOfOperation }])`
 Pastes operation. id is optional as is in `cb.paste()`
 
 

--- a/cytoscape-clipboard.js
+++ b/cytoscape-clipboard.js
@@ -13,13 +13,6 @@
         cytoscape('core', 'clipboard', function (opts) {
             var cy = this;
 
-            var options = {
-                clipboardSize: 0
-            };
-
-            $.extend(true, options, opts);
-
-
             function getScratch() {
                 if (!cy.scratch("_clipboard")) {
                     cy.scratch("_clipboard", { });
@@ -54,7 +47,7 @@
             var oldIdToNewId = {};
 
             function changeIds(jsons) {
-                jsons = $.extend(true, [], jsons);
+                jsons = [].concat(jsons);
                 for (var i = 0; i < jsons.length; i++) {
                     var jsonFirst = jsons[i];
                     var id = getCloneId();

--- a/demo.html
+++ b/demo.html
@@ -6,7 +6,6 @@
 	<title>cytoscape-clipboard demo</title>
 
 	<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
-	<script src="https://code.jquery.com/jquery-3.0.0.min.js"></script>
 
 	<script src="http://cytoscape.github.io/cytoscape.js/api/cytoscape.js-latest/cytoscape.js"></script>
 


### PR DESCRIPTION
`options` wasn't being used and you can use concat instead of jQueries extend. This means you don't need the full jQuery library only for the `extend` function. Also remove `options` from the `README.md` because it did nothing.