### PR TITLE
Allow user to provide custom functions to work on elements when copy/pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,26 @@ Pastes the copied elements which has `id`. If `id` is not specified, it will hav
 ## Default Options
 ```javascript
             var options = {
-                clipboardSize: 0
+                clipboardSize: 0,
+
+                // The following 4 options allow the user to provide custom behavior to
+                // the extension. They can be used to maintain consistency of some data
+                // when elements are duplicated.
+                // These 4 options are set to null by default. The function prototypes
+                // are provided below for explanation purpose only.
+
+                // Function executed on the collection of elements being copied, before
+                // they are serialized in the clipboard
+                beforeCopy: function(eles) {},
+                // Function executed on the clipboard just after the elements are copied.
+                // clipboard is of the form: {nodes: json, edges: json}
+                afterCopy: function(clipboard) {},
+                // Function executed on the clipboard right before elements are pasted,
+                // when they are still in the clipboard.
+                beforePaste: function(clipboard) {},
+                // Function executed on the collection of pasted elements, after they
+                // are pasted.
+                afterPaste: function(eles) {}
             };
 ```
 

--- a/cytoscape-clipboard.js
+++ b/cytoscape-clipboard.js
@@ -14,7 +14,11 @@
             var cy = this;
 
             var options = {
-                clipboardSize: 0
+                clipboardSize: 0,
+                beforeCopy: null,
+                afterCopy: null,
+                beforePaste: null,
+                afterPaste: null
             };
 
             $.extend(true, options, opts);
@@ -95,12 +99,21 @@
                         var nodes = eles.nodes().union(descs).filter(":visible");
                         var edges = nodes.edgesWith(nodes).filter(":visible");
 
+                        if(options.beforeCopy) {
+                            options.beforeCopy(nodes.union(edges));
+                        }
                         clipboard[id] = {nodes: nodes.jsons(), edges: edges.jsons()};
+                        if(options.afterCopy) {
+                            options.afterCopy(clipboard[id]);
+                        }
                         return id;
                     },
                     paste: function (_id) {
                         var id = _id ? _id : getItemId(true);
                         var res = cy.collection();
+                        if(options.beforePaste) {
+                            options.beforePaste(clipboard[id]);
+                        }
                         if (clipboard[id]) {
                             var nodes = changeIds(clipboard[id].nodes);
                             var edges = changeIds(clipboard[id].edges);
@@ -110,6 +123,9 @@
                                 res.select();
                             });
 
+                        }
+                        if(options.afterPaste) {
+                            options.afterPaste(res);
                         }
                         return res;
                     }


### PR DESCRIPTION
This is a proposal to solve the problem of copying nodes with infoboxes. See iVis-at-Bilkent/newt#63

While doing this I also noticed that before all the changes related to infoboxes in Newt, the ids of infoboxes were duplicated on copy/paste and then saved as is in sbgnml. That was leading to duplicated IDs in the xml, which is invalid.

Both problems can be solved easily with these changes. We can use afterPaste() to maintain consistency of the data inside the pasted nodes.